### PR TITLE
Feature/#12 Error Handling + 기존 에러처리 되어있지 않던 뷰에 에러처리 적용(Error Alert)

### DIFF
--- a/galpi/galpi.xcodeproj/project.pbxproj
+++ b/galpi/galpi.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		FDE273A829A2053E00DDD6B3 /* SocialLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE273A729A2053E00DDD6B3 /* SocialLogin.swift */; };
 		FDEFAB7B29BF6C6B00AE1591 /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDEFAB7A29BF6C6B00AE1591 /* View+Extension.swift */; };
 		FDEFAB7D29BF8E8B00AE1591 /* GalpiErrorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDEFAB7C29BF8E8B00AE1591 /* GalpiErrorProtocol.swift */; };
+		FDEFAB8029C0745700AE1591 /* SocialLoginError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDEFAB7F29C0745700AE1591 /* SocialLoginError.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -104,6 +105,7 @@
 		FDE273A729A2053E00DDD6B3 /* SocialLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialLogin.swift; sourceTree = "<group>"; };
 		FDEFAB7A29BF6C6B00AE1591 /* View+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
 		FDEFAB7C29BF8E8B00AE1591 /* GalpiErrorProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalpiErrorProtocol.swift; sourceTree = "<group>"; };
+		FDEFAB7F29C0745700AE1591 /* SocialLoginError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialLoginError.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -239,8 +241,8 @@
 		FD5F78BB2995731500075C7D /* Common */ = {
 			isa = PBXGroup;
 			children = (
-				FDEFAB7E29C071CD00AE1591 /* Error */,
 				FD5F78BC2995731500075C7D /* TabBarContainerView.swift */,
+				FDEFAB7E29C071CD00AE1591 /* Error */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -367,6 +369,7 @@
 			isa = PBXGroup;
 			children = (
 				FDEFAB7C29BF8E8B00AE1591 /* GalpiErrorProtocol.swift */,
+				FDEFAB7F29C0745700AE1591 /* SocialLoginError.swift */,
 			);
 			path = Error;
 			sourceTree = "<group>";
@@ -539,6 +542,7 @@
 				FD894A262989AEC3003E759D /* Galpi.swift in Sources */,
 				9B445DAC2994C7BF00EE436E /* Color+Extension.swift in Sources */,
 				FDA7E4F5299F1E250040F0A3 /* AppleLoginManager.swift in Sources */,
+				FDEFAB8029C0745700AE1591 /* SocialLoginError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/galpi/galpi.xcodeproj/project.pbxproj
+++ b/galpi/galpi.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		FDA7E4F7299FD96B0040F0A3 /* FirebaseAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA7E4F6299FD96B0040F0A3 /* FirebaseAuthService.swift */; };
 		FDE273A429A100A900DDD6B3 /* SocialLoginManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE273A329A100A900DDD6B3 /* SocialLoginManagerProtocol.swift */; };
 		FDE273A829A2053E00DDD6B3 /* SocialLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE273A729A2053E00DDD6B3 /* SocialLogin.swift */; };
+		FDEFAB7B29BF6C6B00AE1591 /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDEFAB7A29BF6C6B00AE1591 /* View+Extension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -100,6 +101,7 @@
 		FDE2739F29A0A9EF00DDD6B3 /* galpi.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = galpi.entitlements; sourceTree = "<group>"; };
 		FDE273A329A100A900DDD6B3 /* SocialLoginManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialLoginManagerProtocol.swift; sourceTree = "<group>"; };
 		FDE273A729A2053E00DDD6B3 /* SocialLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialLogin.swift; sourceTree = "<group>"; };
+		FDEFAB7A29BF6C6B00AE1591 /* View+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -144,6 +146,7 @@
 			children = (
 				9B445DAB2994C7BF00EE436E /* Color+Extension.swift */,
 				9B445DAD2994C88E00EE436E /* Font+Extension.swift */,
+				FDEFAB7A29BF6C6B00AE1591 /* View+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -506,6 +509,7 @@
 				FDA7E4F1299F19DE0040F0A3 /* SocialLoginCredential.swift in Sources */,
 				9BE87B3B2990E6E8002A1B4E /* CalendarView.swift in Sources */,
 				9BB2220B298EBB4F00C25038 /* GalpiTextEditorView.swift in Sources */,
+				FDEFAB7B29BF6C6B00AE1591 /* View+Extension.swift in Sources */,
 				9B5320ED29892B8900F317FD /* FieldView.swift in Sources */,
 				FDA7E4AA2999358C0040F0A3 /* LoginViewModel.swift in Sources */,
 				9B5320EB29892B6200F317FD /* GalpiPostView.swift in Sources */,

--- a/galpi/galpi.xcodeproj/project.pbxproj
+++ b/galpi/galpi.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		FDEFAB7D29BF8E8B00AE1591 /* GalpiErrorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDEFAB7C29BF8E8B00AE1591 /* GalpiErrorProtocol.swift */; };
 		FDEFAB8029C0745700AE1591 /* SocialLoginError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDEFAB7F29C0745700AE1591 /* SocialLoginError.swift */; };
 		FDEFAB8229C0C71000AE1591 /* ServerAuthError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDEFAB8129C0C71000AE1591 /* ServerAuthError.swift */; };
+		FDEFAB8429C0D6EF00AE1591 /* GalpiError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDEFAB8329C0D6EF00AE1591 /* GalpiError.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -108,6 +109,7 @@
 		FDEFAB7C29BF8E8B00AE1591 /* GalpiErrorProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalpiErrorProtocol.swift; sourceTree = "<group>"; };
 		FDEFAB7F29C0745700AE1591 /* SocialLoginError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialLoginError.swift; sourceTree = "<group>"; };
 		FDEFAB8129C0C71000AE1591 /* ServerAuthError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerAuthError.swift; sourceTree = "<group>"; };
+		FDEFAB8329C0D6EF00AE1591 /* GalpiError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalpiError.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -371,6 +373,7 @@
 			isa = PBXGroup;
 			children = (
 				FDEFAB7C29BF8E8B00AE1591 /* GalpiErrorProtocol.swift */,
+				FDEFAB8329C0D6EF00AE1591 /* GalpiError.swift */,
 				FDEFAB8129C0C71000AE1591 /* ServerAuthError.swift */,
 				FDEFAB7F29C0745700AE1591 /* SocialLoginError.swift */,
 			);
@@ -520,6 +523,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FDEFAB7D29BF8E8B00AE1591 /* GalpiErrorProtocol.swift in Sources */,
+				FDEFAB8429C0D6EF00AE1591 /* GalpiError.swift in Sources */,
 				9B445DA92994C6E700EE436E /* GDS.swift in Sources */,
 				9B5320F229895F3000F317FD /* GalpiPostViewModel.swift in Sources */,
 				9B445DAE2994C88E00EE436E /* Font+Extension.swift in Sources */,

--- a/galpi/galpi.xcodeproj/project.pbxproj
+++ b/galpi/galpi.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		FDE273A429A100A900DDD6B3 /* SocialLoginManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE273A329A100A900DDD6B3 /* SocialLoginManagerProtocol.swift */; };
 		FDE273A829A2053E00DDD6B3 /* SocialLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE273A729A2053E00DDD6B3 /* SocialLogin.swift */; };
 		FDEFAB7B29BF6C6B00AE1591 /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDEFAB7A29BF6C6B00AE1591 /* View+Extension.swift */; };
+		FDEFAB7D29BF8E8B00AE1591 /* GalpiErrorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDEFAB7C29BF8E8B00AE1591 /* GalpiErrorProtocol.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -102,6 +103,7 @@
 		FDE273A329A100A900DDD6B3 /* SocialLoginManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialLoginManagerProtocol.swift; sourceTree = "<group>"; };
 		FDE273A729A2053E00DDD6B3 /* SocialLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialLogin.swift; sourceTree = "<group>"; };
 		FDEFAB7A29BF6C6B00AE1591 /* View+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
+		FDEFAB7C29BF8E8B00AE1591 /* GalpiErrorProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalpiErrorProtocol.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -237,6 +239,7 @@
 		FD5F78BB2995731500075C7D /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				FDEFAB7E29C071CD00AE1591 /* Error */,
 				FD5F78BC2995731500075C7D /* TabBarContainerView.swift */,
 			);
 			path = Common;
@@ -358,6 +361,14 @@
 				FDE273A729A2053E00DDD6B3 /* SocialLogin.swift */,
 			);
 			path = SocialLogin;
+			sourceTree = "<group>";
+		};
+		FDEFAB7E29C071CD00AE1591 /* Error */ = {
+			isa = PBXGroup;
+			children = (
+				FDEFAB7C29BF8E8B00AE1591 /* GalpiErrorProtocol.swift */,
+			);
+			path = Error;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -502,6 +513,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FDEFAB7D29BF8E8B00AE1591 /* GalpiErrorProtocol.swift in Sources */,
 				9B445DA92994C6E700EE436E /* GDS.swift in Sources */,
 				9B5320F229895F3000F317FD /* GalpiPostViewModel.swift in Sources */,
 				9B445DAE2994C88E00EE436E /* Font+Extension.swift in Sources */,

--- a/galpi/galpi.xcodeproj/project.pbxproj
+++ b/galpi/galpi.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		FDEFAB7B29BF6C6B00AE1591 /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDEFAB7A29BF6C6B00AE1591 /* View+Extension.swift */; };
 		FDEFAB7D29BF8E8B00AE1591 /* GalpiErrorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDEFAB7C29BF8E8B00AE1591 /* GalpiErrorProtocol.swift */; };
 		FDEFAB8029C0745700AE1591 /* SocialLoginError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDEFAB7F29C0745700AE1591 /* SocialLoginError.swift */; };
+		FDEFAB8229C0C71000AE1591 /* ServerAuthError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDEFAB8129C0C71000AE1591 /* ServerAuthError.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -106,6 +107,7 @@
 		FDEFAB7A29BF6C6B00AE1591 /* View+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
 		FDEFAB7C29BF8E8B00AE1591 /* GalpiErrorProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalpiErrorProtocol.swift; sourceTree = "<group>"; };
 		FDEFAB7F29C0745700AE1591 /* SocialLoginError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialLoginError.swift; sourceTree = "<group>"; };
+		FDEFAB8129C0C71000AE1591 /* ServerAuthError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerAuthError.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -369,6 +371,7 @@
 			isa = PBXGroup;
 			children = (
 				FDEFAB7C29BF8E8B00AE1591 /* GalpiErrorProtocol.swift */,
+				FDEFAB8129C0C71000AE1591 /* ServerAuthError.swift */,
 				FDEFAB7F29C0745700AE1591 /* SocialLoginError.swift */,
 			);
 			path = Error;
@@ -539,6 +542,7 @@
 				FD894A1D29890958003E759D /* GalpiGridView.swift in Sources */,
 				FD8949F22988FFE3003E759D /* galpiApp.swift in Sources */,
 				FD894A2329897C39003E759D /* MockCenter.swift in Sources */,
+				FDEFAB8229C0C71000AE1591 /* ServerAuthError.swift in Sources */,
 				FD894A262989AEC3003E759D /* Galpi.swift in Sources */,
 				9B445DAC2994C7BF00EE436E /* Color+Extension.swift in Sources */,
 				FDA7E4F5299F1E250040F0A3 /* AppleLoginManager.swift in Sources */,

--- a/galpi/galpi/Domain/Common/Error/GalpiError.swift
+++ b/galpi/galpi/Domain/Common/Error/GalpiError.swift
@@ -18,10 +18,10 @@ enum GalpiError: LocalizedError, GalpiErrorProtocol {
         }
     }
     
-    var errorReason: String {
+    var failureReason: String? {
         switch self {
         case .serverAuthError(let error):
-            return error.errorReason
+            return error.failureReason
         }
     }
     

--- a/galpi/galpi/Domain/Common/Error/GalpiError.swift
+++ b/galpi/galpi/Domain/Common/Error/GalpiError.swift
@@ -1,0 +1,28 @@
+//
+//  GalpiError.swift
+//  galpi
+//
+//  Created by minsson on 2023/03/15.
+//
+
+import Foundation
+
+enum GalpiError: LocalizedError, GalpiErrorProtocol {
+    
+    case serverAuthError(ServerAuthError)
+    
+    var code: String {
+        switch self {
+        case .serverAuthError(let error):
+            return error.code
+        }
+    }
+    
+    var errorReason: String {
+        switch self {
+        case .serverAuthError(let error):
+            return error.errorReason
+        }
+    }
+    
+}

--- a/galpi/galpi/Domain/Common/Error/GalpiErrorProtocol.swift
+++ b/galpi/galpi/Domain/Common/Error/GalpiErrorProtocol.swift
@@ -25,7 +25,7 @@ extension GalpiErrorProtocol {
     var recoverySuggestion: String? {
         switch self {
         default:
-            return "다시 해봐도 안 되면 개발자에게 에러 코드를 말씀해주세요. 빠르게 해결해드릴게요! 😸\n" + "(에러코드: \(code))"
+            return "다시 해봐도 안 되면 개발자에게 에러 코드를 말씀해주세요. 빠르게 해결해드릴게요! \n" + "(에러코드: \(code))"
         }
     }
     

--- a/galpi/galpi/Domain/Common/Error/GalpiErrorProtocol.swift
+++ b/galpi/galpi/Domain/Common/Error/GalpiErrorProtocol.swift
@@ -10,7 +10,7 @@ import Foundation
 protocol GalpiErrorProtocol: LocalizedError {
     
     var code: String { get }
-    
+    var errorReason: String { get }
 }
 
 extension GalpiErrorProtocol {

--- a/galpi/galpi/Domain/Common/Error/GalpiErrorProtocol.swift
+++ b/galpi/galpi/Domain/Common/Error/GalpiErrorProtocol.swift
@@ -10,7 +10,7 @@ import Foundation
 protocol GalpiErrorProtocol: LocalizedError {
     
     var code: String { get }
-    var errorReason: String { get }
+    
 }
 
 extension GalpiErrorProtocol {

--- a/galpi/galpi/Domain/Common/Error/GalpiErrorProtocol.swift
+++ b/galpi/galpi/Domain/Common/Error/GalpiErrorProtocol.swift
@@ -1,0 +1,32 @@
+//
+//  GalpiError.swift
+//  galpi
+//
+//  Created by minsson on 2023/03/14.
+//
+
+import Foundation
+
+protocol GalpiErrorProtocol: LocalizedError {
+    
+    var code: String { get }
+    
+}
+
+extension GalpiErrorProtocol {
+    
+    var errorDescription: String? {
+        switch self {
+        default:
+            return "에러가 발생했어요 😿"
+        }
+    }
+    
+    var recoverySuggestion: String? {
+        switch self {
+        default:
+            return "다시 해봐도 안 되면 개발자에게 에러 코드를 말씀해주세요. 빠르게 해결해드릴게요! 😸\n" + "(에러코드: \(code))"
+        }
+    }
+    
+}

--- a/galpi/galpi/Domain/Common/Error/ServerAuthError.swift
+++ b/galpi/galpi/Domain/Common/Error/ServerAuthError.swift
@@ -13,7 +13,7 @@ enum ServerAuthError: GalpiErrorProtocol {
     var code: String {
         switch self {
         case .internalError:
-            return "F100"
+            return "SA100"
         case .socialLoginError(let error):
             return error.code
         }

--- a/galpi/galpi/Domain/Common/Error/ServerAuthError.swift
+++ b/galpi/galpi/Domain/Common/Error/ServerAuthError.swift
@@ -13,7 +13,7 @@ enum ServerAuthError: GalpiErrorProtocol {
     var code: String {
         switch self {
         case .internalError:
-            return "F100"
+            return "S100"
         case .socialLoginError(let error):
             return error.code
         }

--- a/galpi/galpi/Domain/Common/Error/ServerAuthError.swift
+++ b/galpi/galpi/Domain/Common/Error/ServerAuthError.swift
@@ -7,14 +7,11 @@
 
 enum ServerAuthError: GalpiErrorProtocol {
 
-    case internalError
     case socialLoginError(SocialLoginError)
     case custom(String)
     
     var code: String {
         switch self {
-        case .internalError:
-            return "SA100"
         case .socialLoginError(let error):
             return error.code
         case .custom:
@@ -24,8 +21,6 @@ enum ServerAuthError: GalpiErrorProtocol {
     
     var failureReason: String? {
         switch self {
-        case .internalError:
-            return "Server Auth 내부 에러"
         case .socialLoginError(let error):
             return error.failureReason
         case .custom(let customFailureReason):

--- a/galpi/galpi/Domain/Common/Error/ServerAuthError.swift
+++ b/galpi/galpi/Domain/Common/Error/ServerAuthError.swift
@@ -19,12 +19,12 @@ enum ServerAuthError: GalpiErrorProtocol {
         }
     }
     
-    var errorReason: String {
+    var failureReason: String? {
         switch self {
         case .internalError:
             return "Server Auth 내부 에러"
         case .socialLoginError(let error):
-            return error.errorReason
+            return error.failureReason
         }
     }
     

--- a/galpi/galpi/Domain/Common/Error/ServerAuthError.swift
+++ b/galpi/galpi/Domain/Common/Error/ServerAuthError.swift
@@ -13,7 +13,7 @@ enum ServerAuthError: GalpiErrorProtocol {
     var code: String {
         switch self {
         case .internalError:
-            return "S100"
+            return "F100"
         case .socialLoginError(let error):
             return error.code
         }

--- a/galpi/galpi/Domain/Common/Error/ServerAuthError.swift
+++ b/galpi/galpi/Domain/Common/Error/ServerAuthError.swift
@@ -1,0 +1,31 @@
+//
+//  ServerAuthError.swift
+//  galpi
+//
+//  Created by minsson on 2023/03/15.
+//
+
+enum ServerAuthError: GalpiErrorProtocol {
+
+    case internalError
+    case socialLoginError(SocialLoginError)
+    
+    var code: String {
+        switch self {
+        case .internalError:
+            return "F100"
+        case .socialLoginError(let error):
+            return error.code
+        }
+    }
+    
+    var errorReason: String {
+        switch self {
+        case .internalError:
+            return "Server Auth 내부 에러"
+        case .socialLoginError(let error):
+            return error.errorReason
+        }
+    }
+    
+}

--- a/galpi/galpi/Domain/Common/Error/ServerAuthError.swift
+++ b/galpi/galpi/Domain/Common/Error/ServerAuthError.swift
@@ -9,6 +9,7 @@ enum ServerAuthError: GalpiErrorProtocol {
 
     case internalError
     case socialLoginError(SocialLoginError)
+    case custom(String)
     
     var code: String {
         switch self {
@@ -16,6 +17,8 @@ enum ServerAuthError: GalpiErrorProtocol {
             return "SA100"
         case .socialLoginError(let error):
             return error.code
+        case .custom:
+            return "SA999"
         }
     }
     
@@ -25,6 +28,8 @@ enum ServerAuthError: GalpiErrorProtocol {
             return "Server Auth 내부 에러"
         case .socialLoginError(let error):
             return error.failureReason
+        case .custom(let customFailureReason):
+            return customFailureReason
         }
     }
     

--- a/galpi/galpi/Domain/Common/Error/SocialLoginError.swift
+++ b/galpi/galpi/Domain/Common/Error/SocialLoginError.swift
@@ -15,13 +15,13 @@ enum SocialLoginError: GalpiErrorProtocol {
     var code: String {
         switch self {
         case .canceled:
-            return "S100"
+            return "SL100"
         case .internalError:
-            return "S200"
+            return "SL200"
         case .identityToken:
-            return "S300"
+            return "SL300"
         case .idTokenString:
-            return "S400"
+            return "SL400"
         }
     }
     

--- a/galpi/galpi/Domain/Common/Error/SocialLoginError.swift
+++ b/galpi/galpi/Domain/Common/Error/SocialLoginError.swift
@@ -9,8 +9,6 @@ enum SocialLoginError: GalpiErrorProtocol {
     
     case canceled
     case internalError
-    case identityToken
-    case idTokenString
     case custom(String)
     
     var code: String {
@@ -19,10 +17,6 @@ enum SocialLoginError: GalpiErrorProtocol {
             return "SL100"
         case .internalError:
             return "SL200"
-        case .identityToken:
-            return "SL300"
-        case .idTokenString:
-            return "SL400"
         case .custom(_):
             return "SL999"
         }
@@ -34,10 +28,6 @@ enum SocialLoginError: GalpiErrorProtocol {
             return "유저가 인증 절차 취소"
         case .internalError:
             return "유저가 인증 절차를 취소한 것 외의 애플 로그인 기타 에러"
-        case .identityToken:
-            return "identity token의 fetch 실패"
-        case .idTokenString:
-            return "data를 token string으로 직렬화하는 것 실패"
         case .custom(let customFailureReason):
             return customFailureReason
         }

--- a/galpi/galpi/Domain/Common/Error/SocialLoginError.swift
+++ b/galpi/galpi/Domain/Common/Error/SocialLoginError.swift
@@ -25,7 +25,7 @@ enum SocialLoginError: GalpiErrorProtocol {
         }
     }
     
-    var errorReason: String {
+    var failureReason: String? {
         switch self {
         case .canceled:
             return "유저가 인증 절차 취소"

--- a/galpi/galpi/Domain/Common/Error/SocialLoginError.swift
+++ b/galpi/galpi/Domain/Common/Error/SocialLoginError.swift
@@ -9,12 +9,18 @@ enum SocialLoginError: GalpiErrorProtocol {
     
     case canceled
     case internalError
+    case identityToken
+    case idTokenString
     
     var code: String {
         switch self {
         case .canceled:
             return "A100"
         case .internalError:
+            return "A200"
+        case .identityToken:
+            return "A300"
+        case .idTokenString:
             return "A400"
         }
     }

--- a/galpi/galpi/Domain/Common/Error/SocialLoginError.swift
+++ b/galpi/galpi/Domain/Common/Error/SocialLoginError.swift
@@ -8,15 +8,12 @@
 enum SocialLoginError: GalpiErrorProtocol {
     
     case canceled
-    case internalError
     case custom(String)
     
     var code: String {
         switch self {
         case .canceled:
             return "SL100"
-        case .internalError:
-            return "SL200"
         case .custom(_):
             return "SL999"
         }
@@ -26,8 +23,6 @@ enum SocialLoginError: GalpiErrorProtocol {
         switch self {
         case .canceled:
             return "유저가 인증 절차 취소"
-        case .internalError:
-            return "유저가 인증 절차를 취소한 것 외의 애플 로그인 기타 에러"
         case .custom(let customFailureReason):
             return customFailureReason
         }

--- a/galpi/galpi/Domain/Common/Error/SocialLoginError.swift
+++ b/galpi/galpi/Domain/Common/Error/SocialLoginError.swift
@@ -22,7 +22,7 @@ enum SocialLoginError: GalpiErrorProtocol {
     var failureReason: String? {
         switch self {
         case .canceled:
-            return "유저가 인증 절차 취소"
+            return "유저가 소셜 로그인 인증 절차 취소"
         case .custom(let customFailureReason):
             return customFailureReason
         }

--- a/galpi/galpi/Domain/Common/Error/SocialLoginError.swift
+++ b/galpi/galpi/Domain/Common/Error/SocialLoginError.swift
@@ -25,4 +25,17 @@ enum SocialLoginError: GalpiErrorProtocol {
         }
     }
     
+    var errorReason: String {
+        switch self {
+        case .canceled:
+            return "유저가 인증 절차 취소"
+        case .internalError:
+            return "유저가 인증 절차를 취소한 것 외의 애플 로그인 기타 에러"
+        case .identityToken:
+            return "identity token의 fetch 실패"
+        case .idTokenString:
+            return "data를 token string으로 직렬화하는 것 실패"
+        }
+    }
+    
 }

--- a/galpi/galpi/Domain/Common/Error/SocialLoginError.swift
+++ b/galpi/galpi/Domain/Common/Error/SocialLoginError.swift
@@ -11,6 +11,7 @@ enum SocialLoginError: GalpiErrorProtocol {
     case internalError
     case identityToken
     case idTokenString
+    case custom(String)
     
     var code: String {
         switch self {
@@ -22,6 +23,8 @@ enum SocialLoginError: GalpiErrorProtocol {
             return "SL300"
         case .idTokenString:
             return "SL400"
+        case .custom(_):
+            return "SL999"
         }
     }
     
@@ -35,6 +38,8 @@ enum SocialLoginError: GalpiErrorProtocol {
             return "identity token의 fetch 실패"
         case .idTokenString:
             return "data를 token string으로 직렬화하는 것 실패"
+        case .custom(let customFailureReason):
+            return customFailureReason
         }
     }
     

--- a/galpi/galpi/Domain/Common/Error/SocialLoginError.swift
+++ b/galpi/galpi/Domain/Common/Error/SocialLoginError.swift
@@ -15,13 +15,13 @@ enum SocialLoginError: GalpiErrorProtocol {
     var code: String {
         switch self {
         case .canceled:
-            return "A100"
+            return "S100"
         case .internalError:
-            return "A200"
+            return "S200"
         case .identityToken:
-            return "A300"
+            return "S300"
         case .idTokenString:
-            return "A400"
+            return "S400"
         }
     }
     

--- a/galpi/galpi/Domain/Common/Error/SocialLoginError.swift
+++ b/galpi/galpi/Domain/Common/Error/SocialLoginError.swift
@@ -1,0 +1,22 @@
+//
+//  AppleLoginError.swift
+//  galpi
+//
+//  Created by minsson on 2023/03/14.
+//
+
+enum SocialLoginError: GalpiErrorProtocol {
+    
+    case canceled
+    case internalError
+    
+    var code: String {
+        switch self {
+        case .canceled:
+            return "A100"
+        case .internalError:
+            return "A400"
+        }
+    }
+    
+}

--- a/galpi/galpi/Domain/Login/LoginView.swift
+++ b/galpi/galpi/Domain/Login/LoginView.swift
@@ -32,6 +32,7 @@ struct LoginView: View {
                     }
                     .padding(.bottom, 90)
             }
+            .errorAlert(error: $viewModel.error)
         }
     }
     

--- a/galpi/galpi/Domain/Login/LoginViewModel.swift
+++ b/galpi/galpi/Domain/Login/LoginViewModel.swift
@@ -30,7 +30,7 @@ final class LoginViewModel: ObservableObject {
             case .success(let isSignedIn):
                 self.isSignedIn = isSignedIn
             case .failure(let error):
-                print(error)
+                self.error = GalpiError.serverAuthError(error)
             }
         }
     }

--- a/galpi/galpi/Domain/Login/LoginViewModel.swift
+++ b/galpi/galpi/Domain/Login/LoginViewModel.swift
@@ -10,6 +10,7 @@ import Foundation
 final class LoginViewModel: ObservableObject {
     
     @Published private(set) var isSignedIn = false
+    @Published var error: GalpiError?
     
     private let serverAuthService: ServerAuthServiceProtocol
     

--- a/galpi/galpi/Domain/Login/LoginViewModel.swift
+++ b/galpi/galpi/Domain/Login/LoginViewModel.swift
@@ -30,6 +30,7 @@ final class LoginViewModel: ObservableObject {
             case .success(let isSignedIn):
                 self.isSignedIn = isSignedIn
             case .failure(let error):
+                print(error.failureReason as Any)
                 self.error = GalpiError.serverAuthError(error)
             }
         }

--- a/galpi/galpi/Extension/View+Extension.swift
+++ b/galpi/galpi/Extension/View+Extension.swift
@@ -1,0 +1,21 @@
+//
+//  View+Extension.swift
+//  galpi
+//
+//  Created by minsson on 2023/03/13.
+//
+
+import SwiftUI
+
+extension View {
+    func errorAlert<E: LocalizedError>(error: Binding<E?>, buttonTitle: String = "알겠어요 ☺️") -> some View {
+        let localizedError = error.wrappedValue
+        return alert(isPresented: .constant(localizedError != nil), error: localizedError) { _ in
+            Button(buttonTitle) {
+                error.wrappedValue = nil
+            }
+        } message: { error in
+            Text(error.recoverySuggestion ?? "")
+        }
+    }
+}

--- a/galpi/galpi/Services/OAuth/FirebaseAuthService.swift
+++ b/galpi/galpi/Services/OAuth/FirebaseAuthService.swift
@@ -10,7 +10,7 @@ import FirebaseAuth
 protocol ServerAuthServiceProtocol {
     
     var isSignedIn: Bool { get }
-    func signIn(with socialLogin: SocialLogin, completion: @escaping (Result<Bool, Error>) -> Void)
+    func signIn(with socialLogin: SocialLogin, completion: @escaping (Result<Bool, ServerAuthError>) -> Void)
     
 }
 
@@ -22,7 +22,7 @@ final class FirebaseAuthService: ServerAuthServiceProtocol {
     
     var socialLoginManager: SocialLoginManagerProtocol?
 
-    func signIn(with socialLogin: SocialLogin, completion: @escaping (Result<Bool, Error>) -> Void) {
+    func signIn(with socialLogin: SocialLogin, completion: @escaping (Result<Bool, ServerAuthError>) -> Void) {
         socialLoginManager = socialLogin.loginManager
         
         socialLoginManager?.signIn { credentialResult in

--- a/galpi/galpi/Services/OAuth/FirebaseAuthService.swift
+++ b/galpi/galpi/Services/OAuth/FirebaseAuthService.swift
@@ -32,7 +32,7 @@ final class FirebaseAuthService: ServerAuthServiceProtocol {
                 
                 Auth.auth().signIn(with: firebaseCredential) { (authResult, error) in
                     guard error == nil else {
-                        completion(.failure(ServerAuthError.internalError))
+                        completion(.failure(ServerAuthError.custom(error?.localizedDescription ?? "")))
                         return
                     }
                     

--- a/galpi/galpi/Services/OAuth/FirebaseAuthService.swift
+++ b/galpi/galpi/Services/OAuth/FirebaseAuthService.swift
@@ -31,8 +31,8 @@ final class FirebaseAuthService: ServerAuthServiceProtocol {
                 let firebaseCredential = self.firebaseCredential(socialAuthCredential: socialAuthcredential)
                 
                 Auth.auth().signIn(with: firebaseCredential) { (authResult, error) in
-                    if let error = error {
-                        print(error)
+                    guard error == nil else {
+                        completion(.failure(ServerAuthError.internalError))
                         return
                     }
                     
@@ -40,7 +40,7 @@ final class FirebaseAuthService: ServerAuthServiceProtocol {
                 }
     
             case .failure(let error):
-                print(error)
+                completion(.failure(ServerAuthError.socialLoginError(error)))
             }
         }
     }

--- a/galpi/galpi/Services/OAuth/SocialLogin/AppleLoginManager.swift
+++ b/galpi/galpi/Services/OAuth/SocialLogin/AppleLoginManager.swift
@@ -12,9 +12,9 @@ import FirebaseAuth
 final class AppleLoginManager: NSObject, SocialLoginManagerProtocol {
     
     let nonce = NonceManager().randomNonceString()
-    private var signInCompletion: ((Result<SocialLoginCredential, Error>) -> Void)?
+    private var signInCompletion: ((Result<SocialLoginCredential, SocialLoginError>) -> Void)?
     
-    func signIn(completion: @escaping (Result<SocialLoginCredential, Error>) -> Void) {
+    func signIn(completion: @escaping (Result<SocialLoginCredential, SocialLoginError>) -> Void) {
         configureAuthorizationController()
         
         signInCompletion = completion

--- a/galpi/galpi/Services/OAuth/SocialLogin/AppleLoginManager.swift
+++ b/galpi/galpi/Services/OAuth/SocialLogin/AppleLoginManager.swift
@@ -64,7 +64,7 @@ extension AppleLoginManager: ASAuthorizationControllerDelegate {
         case .canceled:
             signInCompletion?(.failure(SocialLoginError.canceled))
         default:
-            signInCompletion?(.failure(SocialLoginError.internalError))
+            signInCompletion?(.failure(SocialLoginError.custom(authError.localizedDescription)))
         }
     }
     

--- a/galpi/galpi/Services/OAuth/SocialLogin/AppleLoginManager.swift
+++ b/galpi/galpi/Services/OAuth/SocialLogin/AppleLoginManager.swift
@@ -42,11 +42,11 @@ extension AppleLoginManager: ASAuthorizationControllerDelegate {
     func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
         if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
             guard let appleIDToken = appleIDCredential.identityToken else {
-                signInCompletion?(.failure(SocialLoginError.internalError))
+                signInCompletion?(.failure(SocialLoginError.custom("identity token이 fetch 되지 않음")))
                 return
             }
             guard let idTokenString = String(data: appleIDToken, encoding: .utf8) else {
-                signInCompletion?(.failure(SocialLoginError.idTokenString))
+                signInCompletion?(.failure(SocialLoginError.custom("data가 token string으로 직렬화되지 않음")))
                 return
             }
             

--- a/galpi/galpi/Services/OAuth/SocialLogin/SocialLoginManagerProtocol.swift
+++ b/galpi/galpi/Services/OAuth/SocialLogin/SocialLoginManagerProtocol.swift
@@ -10,6 +10,6 @@ import Foundation
 protocol SocialLoginManagerProtocol {
     
     var nonce: String { get }
-    func signIn(completion: @escaping (Result<SocialLoginCredential, Error>) -> Void)
+    func signIn(completion: @escaping (Result<SocialLoginCredential, SocialLoginError>) -> Void)
     
 }


### PR DESCRIPTION
@jcrescent61 

안녕하세요, 엘렌!
오랜만에 보내는 PR이네요! 마무리까지 힘내봅시다! 😁

## 구현 내용
- 모든 뷰에서 편리하게 사용할 수 있는 Error Alert Modifier를 구현했습니다.
    ```swift
    func errorAlert<E: LocalizedError>(error: Binding<E?>, buttonTitle: String = "알겠어요 ☺️") -> some View
    ```
    - 뷰모델에서 LocalizedError 프로토콜을 채택한 타입인 Published Property를 들고 있고, 뷰에서 이 프로퍼티를 바인딩해 errorAlert 모디파이에 넣어주면, 바인딩 된 error 프로퍼티가 업데이트될 때마다 Error Alert를 띄워주는 방식입니다.
- 앱 전반적으로 사용할 에러 프로토콜과 모델을 구현했습니다.
    - GalpiErrorProtocol, GalpiError 입니다.
    - LocalizedError 프로토콜을 채택해 유저에게 보여줄 errorDescription, recoverySuggestion을 갖고 있습니다.
    - 다만 완벽한 에러처리를 위해서는 모든 에러케이스에 대해 구체적인 errorDescription, recoverySuggestion를 Alert로 띄워줘야겠지만, 현재 단계에서는 일종의 오버엔지니어링이라고 생각해 범용적인 에러메시지를 사용하고 있습니다. 만약 추후 필요하다면 errorDescription과 recoverySuggestion의 String들만 바꿔주면 됩니다.
    - 따라서, 현재의 Error Alert 내용은 아래와 같습니다.
        - Alert의 타이틀(errorDescription): '에러가 발생했어요 😿'로 통일
       - Alert의 내용(recoverySuggestion): '다시 해봐도 안 되면 개발자에게 에러 코드를 말씀해주세요. 빠르게 해결해드릴게요! + (에러코드: @@@)'
            | Error Alert 예시 이미지 |
            | :-: | 
            | <img src = "https://user-images.githubusercontent.com/96630194/225217758-6587689c-e291-4b58-b6b5-622b683ffae0.png" height="500px"> | 
- 필요하다면 각 객체마다 에러 타입을 구현할 수 있습니다. LoginView에서 FirebaseAuth를 통해 애플 로그인을 하는 것과 관련, GalpiErrorProtocol을 채택한 ServerAuthError와 SocialLoginError 타입을 구현해두었습니다. 
    - 이런 에러들은 컴플리션 핸들러와 Result 타입, 그리고 enum의 연관값을 이용해 더 작은 집합의 에러에서 더 큰 집합의 에러로 넘어가, 최종적으로 View Model에 도달해 Error Alert로 띄워집니다.
    - 예를 들어, 애플 로그인에서 `SocialLoginError.canceled` 에러가 다른 객체로 넘어가는 방식은 아래와 같습니다.
        - AppleLoginManager에서 `SocialLoginError.canceled` 발생 -> FirebaseAuthService에 `SocialLoginError.canceled` 전달
        - FirebaseAuthService에서는 AppleLoginManager에서 온 에러를 ServerAuthError의 socialLoginError(SocialLoginError)로 받음 -> LoginViewModel에 `ServerAuthError.socialLoginError(SocialLoginError.canceled)` 전달
        - LoginViewModel에서는 FirebaseAuthService에서 온 에러를 GalpiError의 serverAuthError(ServerAuthError)로 받음 -> self.error에 `GalpiError.serverAuthError(ServerAuthError.socialLoginError(SocialLoginError.canceled)` 할당
        - LoginView에서 `.errorAlert(error: $viewModel.error)`를 통해 LoginViewModel 내 error 프로퍼티의 업데이트 여부  확인 -> 업데이트 되면 Error Alert를 띄움

## 고민했던 점
- 위와 같이 에러처리를 할 때의 장단점
-  저는 장점이 더 크다고 생각해 이렇게 구현했는데, 엘렌은 어떻게 생각하시는지 궁금합니다.
    - 장점:
        - 각 뷰에서 하나의 errorAlert 모디파이어, 각 뷰모델에서 하나의 error Published Property만 만들어주면 되어 편리함
        - 에러처리의 구조가 짜여있으므로, 앱이 확장되더라도 구조에 맞춰 에러 타입과 케이스만 정의해주면 되어 편리함
    - 단점:
        - 에러 타입의 수가 늘어남
        - 더 작은 에러에서 더 큰 에러로 넘어가며 전달되는 구조가 복잡하게 느껴질 수 있음  

## linked issue
- #12 
